### PR TITLE
Preserve argument quoting for all git commands

### DIFF
--- a/conf.d/scmpuff.fish
+++ b/conf.d/scmpuff.fish
@@ -29,9 +29,7 @@ function git
     case add
         eval command (scmpuff expand -- "$SCMPUFF_GIT_CMD" $argv)
         scmpuff_status
-    case config
-        eval command "$SCMPUFF_GIT_CMD" (string escape -- $argv)
     case '*'
-        eval command "$SCMPUFF_GIT_CMD" $argv
+        eval command "$SCMPUFF_GIT_CMD" (string escape -- $argv)
     end
 end


### PR DESCRIPTION
Without this, something like `git clean 'foo bar'` will result in scmpuff.fish calling `/usr/local/bin/git clean foo bar`.  It ought to be calling `/usr/local/bin/git clean 'foo bar'`.

Or am I missing something?